### PR TITLE
Refactor how it works section with device cards

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 
 const summaryCards = [
@@ -15,6 +16,30 @@ const summaryCards = [
     title: "Wallet summary",
     metric: "Transparent payouts",
     description: "Track balances, requests, and tips from a single dashboard.",
+  },
+];
+
+const howItWorksSteps = [
+  {
+    title: "Discover local experts",
+    description:
+      "Browse a curated map of locals, filter by specialty, and invite the right hosts into every itinerary.",
+    image: "/how-step-1.svg",
+    imageAlt: "Organizer browsing Traferr locals on the mobile app.",
+  },
+  {
+    title: "Confirm availability",
+    description:
+      "Check live calendars, review rates, and lock in the people who can welcome your travelers on the right dates.",
+    image: "/how-step-2.svg",
+    imageAlt: "Availability details for a Traferr local inside the app.",
+  },
+  {
+    title: "Coordinate on the go",
+    description:
+      "Message, share updates, and keep every traveler synced with transparent tasks and payment status in one place.",
+    image: "/how-step-3.svg",
+    imageAlt: "In-app messaging thread between a traveler and a local host.",
   },
 ];
 
@@ -94,6 +119,43 @@ export default function Home() {
                 <p className="mt-3 text-lg font-semibold text-slate-900">{card.metric}</p>
                 <p className="mt-2 text-sm text-slate-600">{card.description}</p>
               </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-white/90 px-4">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 py-16">
+          <div className="space-y-4 text-center">
+            <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">How it works</p>
+            <h2 className="text-3xl font-semibold text-slate-900">Guide every journey in three steps</h2>
+            <p className="mx-auto max-w-2xl text-base text-slate-600">
+              Give your travelers clarity before they depart. Traferr keeps discovery, coordination, and follow-up aligned so
+              every local partnership feels effortless.
+            </p>
+          </div>
+          <div className="grid gap-8 md:grid-cols-3">
+            {howItWorksSteps.map((step) => (
+              <article
+                key={step.title}
+                className="flex h-full flex-col items-center gap-6 rounded-3xl border border-slate-200 bg-white/80 p-6 text-center shadow-lg shadow-slate-200/60"
+              >
+                <div className="relative w-full max-w-[220px]">
+                  <div className="relative aspect-[9/19.5] w-full">
+                    <div className="absolute inset-0 rounded-[2.75rem] border border-slate-900/15 bg-slate-900 shadow-[0_22px_50px_rgba(15,23,42,0.28)]">
+                      <div className="absolute inset-[12px] overflow-hidden rounded-[2rem] bg-slate-900">
+                        <Image src={step.image} alt={step.imageAlt} fill className="object-cover" sizes="(max-width: 768px) 200px, 220px" />
+                      </div>
+                      <div className="absolute left-1/2 top-3 h-1.5 w-16 -translate-x-1/2 rounded-full bg-slate-700" aria-hidden />
+                      <div className="absolute left-1/2 bottom-3 h-1 w-20 -translate-x-1/2 rounded-full bg-slate-700/60" aria-hidden />
+                    </div>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+                  <p className="text-sm text-slate-600">{step.description}</p>
+                </div>
+              </article>
             ))}
           </div>
         </div>

--- a/public/how-step-1.svg
+++ b/public/how-step-1.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 780">
+  <defs>
+    <linearGradient id="gradient-step-1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="card-1" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.95)" />
+      <stop offset="100%" stop-color="rgba(241,245,249,0.9)" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="780" fill="url(#gradient-step-1)" />
+  <g opacity="0.15" fill="#f8fafc">
+    <circle cx="70" cy="110" r="42" />
+    <circle cx="310" cy="180" r="32" />
+    <circle cx="120" cy="620" r="28" />
+  </g>
+  <g transform="translate(28 120)">
+    <rect width="304" height="132" rx="28" fill="url(#card-1)" />
+    <rect x="24" y="24" width="168" height="20" rx="10" fill="#0ea5e9" opacity="0.9" />
+    <rect x="24" y="60" width="216" height="14" rx="7" fill="#1e293b" opacity="0.75" />
+    <rect x="24" y="92" width="152" height="14" rx="7" fill="#334155" opacity="0.55" />
+    <circle cx="256" cy="86" r="26" fill="#38bdf8" opacity="0.75" />
+    <circle cx="256" cy="86" r="12" fill="#0f172a" opacity="0.7" />
+  </g>
+  <g transform="translate(28 296)">
+    <rect width="304" height="312" rx="36" fill="rgba(15,23,42,0.45)" />
+    <rect x="32" y="40" width="112" height="112" rx="24" fill="#f8fafc" opacity="0.92" />
+    <rect x="168" y="40" width="104" height="16" rx="8" fill="#e2e8f0" />
+    <rect x="168" y="72" width="72" height="12" rx="6" fill="#cbd5f5" />
+    <rect x="168" y="104" width="88" height="12" rx="6" fill="#e2e8f0" />
+    <rect x="32" y="176" width="240" height="16" rx="8" fill="#38bdf8" opacity="0.9" />
+    <rect x="32" y="212" width="176" height="12" rx="6" fill="#e2e8f0" />
+    <rect x="32" y="244" width="136" height="12" rx="6" fill="#cbd5f5" />
+  </g>
+  <g transform="translate(44 656)" opacity="0.9">
+    <rect width="272" height="56" rx="20" fill="rgba(15,23,42,0.35)" />
+    <rect x="24" y="18" width="136" height="12" rx="6" fill="#f8fafc" opacity="0.9" />
+    <rect x="24" y="36" width="88" height="8" rx="4" fill="#bae6fd" opacity="0.85" />
+    <circle cx="226" cy="28" r="14" fill="#38bdf8" />
+    <circle cx="258" cy="28" r="14" fill="#0ea5e9" />
+  </g>
+</svg>

--- a/public/how-step-2.svg
+++ b/public/how-step-2.svg
@@ -1,0 +1,48 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 780">
+  <defs>
+    <linearGradient id="gradient-step-2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#818cf8" />
+      <stop offset="100%" stop-color="#312e81" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="780" fill="url(#gradient-step-2)" />
+  <g opacity="0.18" fill="#eef2ff">
+    <circle cx="90" cy="140" r="40" />
+    <circle cx="280" cy="112" r="24" />
+    <circle cx="306" cy="620" r="36" />
+    <circle cx="72" cy="520" r="28" />
+  </g>
+  <g transform="translate(36 120)">
+    <rect width="288" height="104" rx="28" fill="rgba(15,23,42,0.55)" />
+    <rect x="24" y="24" width="128" height="16" rx="8" fill="#c7d2fe" opacity="0.95" />
+    <rect x="24" y="54" width="168" height="12" rx="6" fill="#e0e7ff" opacity="0.9" />
+    <rect x="24" y="78" width="96" height="10" rx="5" fill="#c7d2fe" opacity="0.85" />
+    <circle cx="244" cy="52" r="24" fill="#f1f5f9" opacity="0.92" />
+    <circle cx="244" cy="52" r="10" fill="#818cf8" opacity="0.85" />
+  </g>
+  <g transform="translate(28 268)">
+    <rect width="304" height="332" rx="32" fill="rgba(15,23,42,0.55)" />
+    <rect x="36" y="48" width="232" height="20" rx="10" fill="#c7d2fe" opacity="0.95" />
+    <rect x="36" y="84" width="184" height="12" rx="6" fill="#e0e7ff" opacity="0.85" />
+    <rect x="36" y="112" width="148" height="12" rx="6" fill="#c7d2fe" opacity="0.8" />
+    <rect x="36" y="152" width="232" height="16" rx="8" fill="#f8fafc" opacity="0.92" />
+    <g transform="translate(36 196)">
+      <rect width="232" height="88" rx="20" fill="rgba(248,250,252,0.95)" />
+      <rect x="20" y="20" width="128" height="14" rx="7" fill="#312e81" opacity="0.8" />
+      <rect x="20" y="46" width="96" height="10" rx="5" fill="#94a3ff" opacity="0.7" />
+      <rect x="20" y="66" width="112" height="10" rx="5" fill="#c7d2fe" opacity="0.7" />
+      <rect x="168" y="28" width="44" height="44" rx="12" fill="#818cf8" opacity="0.9" />
+    </g>
+    <g transform="translate(36 296)">
+      <rect width="152" height="12" rx="6" fill="#c7d2fe" opacity="0.7" />
+      <rect x="168" width="68" height="12" rx="6" fill="#a5b4fc" opacity="0.6" />
+    </g>
+  </g>
+  <g transform="translate(56 648)" opacity="0.9">
+    <rect width="248" height="60" rx="24" fill="rgba(15,23,42,0.45)" />
+    <rect x="24" y="18" width="152" height="14" rx="7" fill="#eef2ff" opacity="0.9" />
+    <rect x="24" y="40" width="112" height="10" rx="5" fill="#c7d2fe" opacity="0.85" />
+    <circle cx="210" cy="30" r="14" fill="#818cf8" />
+    <circle cx="238" cy="30" r="14" fill="#6366f1" />
+  </g>
+</svg>

--- a/public/how-step-3.svg
+++ b/public/how-step-3.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 780">
+  <defs>
+    <linearGradient id="gradient-step-3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f472b6" />
+      <stop offset="100%" stop-color="#312e81" />
+    </linearGradient>
+  </defs>
+  <rect width="360" height="780" fill="url(#gradient-step-3)" />
+  <g opacity="0.12" fill="#fee2e2">
+    <circle cx="96" cy="160" r="44" />
+    <circle cx="284" cy="132" r="36" />
+    <circle cx="284" cy="556" r="42" />
+    <circle cx="80" cy="620" r="32" />
+  </g>
+  <g transform="translate(24 128)">
+    <rect width="312" height="104" rx="32" fill="rgba(15,23,42,0.4)" />
+    <rect x="28" y="30" width="152" height="16" rx="8" fill="#fce7f3" opacity="0.95" />
+    <rect x="28" y="60" width="118" height="12" rx="6" fill="#fbcfe8" opacity="0.8" />
+    <circle cx="256" cy="52" r="26" fill="#f8fafc" opacity="0.9" />
+    <circle cx="256" cy="52" r="12" fill="#f472b6" opacity="0.8" />
+  </g>
+  <g transform="translate(36 272)">
+    <rect width="288" height="320" rx="36" fill="rgba(15,23,42,0.55)" />
+    <g transform="translate(28 40)">
+      <rect width="232" height="56" rx="18" fill="rgba(248,250,252,0.95)" />
+      <circle cx="28" cy="28" r="16" fill="#f472b6" opacity="0.9" />
+      <rect x="60" y="16" width="108" height="12" rx="6" fill="#312e81" opacity="0.75" />
+      <rect x="60" y="36" width="132" height="10" rx="5" fill="#c4b5fd" opacity="0.6" />
+      <rect x="196" y="20" width="24" height="24" rx="6" fill="#f472b6" opacity="0.85" />
+    </g>
+    <g transform="translate(28 116)">
+      <rect width="232" height="56" rx="18" fill="rgba(248,250,252,0.9)" />
+      <circle cx="28" cy="28" r="16" fill="#f8fafc" opacity="0.85" />
+      <rect x="60" y="16" width="108" height="12" rx="6" fill="#f9a8d4" opacity="0.9" />
+      <rect x="60" y="36" width="132" height="10" rx="5" fill="#ffe4e6" opacity="0.7" />
+      <rect x="196" y="20" width="24" height="24" rx="6" fill="#f472b6" opacity="0.6" />
+    </g>
+    <g transform="translate(28 192)">
+      <rect width="232" height="56" rx="18" fill="rgba(248,250,252,0.88)" />
+      <circle cx="28" cy="28" r="16" fill="#f8fafc" opacity="0.85" />
+      <rect x="60" y="16" width="132" height="12" rx="6" fill="#fdf2f8" opacity="0.7" />
+      <rect x="60" y="36" width="104" height="10" rx="5" fill="#fbcfe8" opacity="0.6" />
+      <rect x="196" y="20" width="24" height="24" rx="6" fill="#f472b6" opacity="0.5" />
+    </g>
+    <g transform="translate(28 268)">
+      <rect width="164" height="12" rx="6" fill="#fbcfe8" opacity="0.65" />
+      <rect x="180" width="80" height="12" rx="6" fill="#fdf2f8" opacity="0.5" />
+    </g>
+  </g>
+  <g transform="translate(60 660)" opacity="0.95">
+    <rect width="240" height="56" rx="22" fill="rgba(15,23,42,0.4)" />
+    <rect x="24" y="18" width="120" height="12" rx="6" fill="#fce7f3" opacity="0.95" />
+    <rect x="24" y="36" width="96" height="10" rx="5" fill="#fbcfe8" opacity="0.8" />
+    <circle cx="202" cy="28" r="14" fill="#f472b6" />
+    <circle cx="230" cy="28" r="14" fill="#ec4899" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add three-step "How it works" section with iPhone-inspired card layout
- introduce new illustrative SVG screens for each step to anchor the device mockups
- integrate responsive styling to keep the section cohesive with the rest of the landing page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceacd29904832ea8d2ccc22cf5eaa1