### PR TITLE
Update How It Works cards layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,27 +1,28 @@
 @import "tailwindcss";
 
 :root {
-  color-scheme: dark;
-color-scheme: dark;
---background: #05070c;
---foreground: #eef3ff;
+  color-scheme: light;
+  /* Update these custom properties to tweak the global background theme in one place. */
+  --background-base: #f1f7ff;
+  --background-gradient:
+    radial-gradient(
+      120% 85% at 50% -10%,
+      rgba(152, 197, 255, 0.35) 0%,
+      rgba(214, 237, 255, 0.28) 35%,
+      rgba(241, 249, 255, 0) 70%
+    ),
+    linear-gradient(180deg, #f6fbff 0%, #e0f1ff 55%, #d9ecff 100%);
+  --foreground: #0f172a;
 }
 
 @theme inline {
-  --color-background: var(--background);
+  --color-background: var(--background-base);
   --color-foreground: var(--foreground);
 }
 
 body {
-  background-color: var(--background);
-  background-image:
-    radial-gradient(
-120% 75% at 50% 112%,
-rgba(80, 140, 255, 0.25) 0%,
-rgba(16, 26, 52, 0.06) 50%,
-rgba(5, 6, 8, 0) 75%
-),
-linear-gradient(180deg, #05070f 0%, #060913 45%, #0b1224 100%);
+  background-color: var(--background-base);
+  background-image: var(--background-gradient);
   background-attachment: fixed;
   background-repeat: no-repeat;
   color: var(--foreground);
@@ -29,4 +30,6 @@ linear-gradient(180deg, #05070f 0%, #060913 45%, #0b1224 100%);
   min-height: 100vh;
 }
 
-html { scroll-behavior: smooth; }
+html {
+  scroll-behavior: smooth;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,9 @@
     ),
     linear-gradient(180deg, #f6fbff 0%, #e0f1ff 55%, #d9ecff 100%);
   --foreground: #0f172a;
+  /* Adjust these to keep vertical rhythm consistent across sections. */
+  --section-gap: clamp(2rem, 1.2vw + 1.35rem, 2.75rem);
+  --section-padding-block: clamp(2.25rem, 1.5vw + 1.5rem, 3rem);
 }
 
 @theme inline {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
       <head>
         <link rel="icon" href="/favicon.svg" />
       </head>
-      <body className="bg-slate-50 text-slate-900 antialiased">
+      <body className="text-slate-900 antialiased">
         <div className="flex min-h-screen flex-col">
           <Header />
           <main className="flex-1">{children}</main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,13 +25,13 @@ export default function Home() {
           style={{ paddingBottom: "var(--section-padding-block)" }}
         >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-            <span className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-5 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-sky-600">
+            <span className="inline-flex items-center gap-3 rounded-full border border-sky-200 bg-white/80 px-5 py-1.5 text-xs font-semibold uppercase tracking-[0.32em] text-sky-600">
               <Image
                 src="/traferr-logo.svg"
                 alt="Traferr logo"
-                width={20}
-                height={20}
-                className="h-5 w-5 drop-shadow-sm"
+                width={28}
+                height={28}
+                className="h-7 w-7 drop-shadow-[0_10px_22px_rgba(56,189,248,0.3)]"
               />
               <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
                 Traferr

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,18 +25,21 @@ export default function Home() {
           style={{ paddingBottom: "var(--section-padding-block)" }}
         >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-            <span className="inline-flex items-center gap-3 rounded-full border border-sky-200 bg-white/80 px-5 py-1.5 text-xs font-semibold uppercase tracking-[0.32em] text-sky-600">
-              <Image
-                src="/traferr-logo.svg"
-                alt="Traferr logo"
-                width={28}
-                height={28}
-                className="h-7 w-7 drop-shadow-[0_10px_22px_rgba(56,189,248,0.3)]"
-              />
+            <div className="relative inline-flex items-center gap-3 overflow-visible rounded-full border border-sky-200 bg-white/80 px-6 py-2 pl-16 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-sky-600 shadow-sm">
+              <span className="pointer-events-none absolute -left-11 top-1/2 flex h-20 w-20 -translate-y-1/2 items-center justify-center">
+                <span className="absolute inset-0 rounded-full bg-gradient-to-br from-sky-300 via-sky-400 to-indigo-400 opacity-60 blur-2xl" />
+                <Image
+                  src="/traferr-logo.svg"
+                  alt="Traferr logo"
+                  width={64}
+                  height={64}
+                  className="relative h-12 w-12 drop-shadow-[0_18px_36px_rgba(56,189,248,0.45)]"
+                />
+              </span>
               <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
                 Traferr
               </span>
-            </span>
+            </div>
             <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
               Have you talked to someone new today?
             </h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,18 +81,38 @@ export default function Home() {
 
       <section id="why-i-need-this" className="px-4">
         <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-10 rounded-3xl border border-slate-200 bg-slate-50 px-6 py-16 shadow-xl shadow-sky-100/40">
-          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-start">
-            <div className="max-w-2xl space-y-4">
-              <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">
-                Why I need this
-              </p>
-              <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-                Social feeds broadcast. Traferr has a back-and-forth.
-              </h2>
-              <p className="text-base leading-relaxed text-slate-600">
-                Skip the endless scroll and tap into someone who actually lives there. It’s faster,
-                calmer, and finally personal.
-              </p>
+          <div className="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start">
+            <div className="flex flex-col gap-8">
+              <div className="max-w-2xl space-y-4">
+                <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">
+                  Why I need this
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+                  Social feeds broadcast. Traferr has a back-and-forth.
+                </h2>
+                <p className="text-base leading-relaxed text-slate-600">
+                  Skip the endless scroll and tap into someone who actually lives there. It’s faster,
+                  calmer, and finally personal.
+                </p>
+              </div>
+              <div className="grid gap-6 sm:grid-cols-2">
+                <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <h3 className="text-lg font-semibold text-slate-900">Endless social feeds</h3>
+                  <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
+                    <li>Everyone’s shouting, no one’s listening.</li>
+                    <li>Recommendations drowned in ads and outdated threads.</li>
+                    <li>You leave with more tabs, not clarity.</li>
+                  </ul>
+                </article>
+                <article className="rounded-3xl border border-sky-100 bg-white p-6 shadow-[0_20px_60px_-24px_rgba(56,189,248,0.5)]">
+                  <h3 className="text-lg font-semibold text-slate-900">Direct conversation</h3>
+                  <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
+                    <li>Talk to the person who walks those streets every day.</li>
+                    <li>Ask follow-ups instantly—no threads to refresh.</li>
+                    <li>Walk away with confidence in your next move.</li>
+                  </ul>
+                </article>
+              </div>
             </div>
             <div className="relative isolate overflow-hidden rounded-3xl border border-sky-100 bg-white p-3 shadow-[0_24px_80px_-40px_rgba(56,189,248,0.55)]">
               <div className="aspect-video w-full overflow-hidden rounded-2xl bg-gradient-to-br from-sky-100 via-white to-sky-50">
@@ -114,24 +134,6 @@ export default function Home() {
                 </div>
               </div>
             </div>
-          </div>
-          <div className="grid gap-6 md:grid-cols-2">
-            <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-slate-900">Endless social feeds</h3>
-              <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
-                <li>Everyone’s shouting, no one’s listening.</li>
-                <li>Recommendations drowned in ads and outdated threads.</li>
-                <li>You leave with more tabs, not clarity.</li>
-              </ul>
-            </article>
-            <article className="rounded-3xl border border-sky-100 bg-white p-6 shadow-[0_20px_60px_-24px_rgba(56,189,248,0.5)]">
-              <h3 className="text-lg font-semibold text-slate-900">Direct conversation</h3>
-              <ul className="mt-4 space-y-2 text-sm leading-relaxed text-slate-600">
-                <li>Talk to the person who walks those streets every day.</li>
-                <li>Ask follow-ups instantly—no threads to refresh.</li>
-                <li>Walk away with confidence in your next move.</li>
-              </ul>
-            </article>
           </div>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,18 +25,30 @@ export default function Home() {
           style={{ paddingBottom: "var(--section-padding-block)" }}
         >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-            <div className="inline-flex items-center gap-4 rounded-full border border-sky-200 bg-white/80 px-6 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-sky-600 shadow-sm">
-              <Image
-                src="/traferr-logo.svg"
-                alt="Traferr logo"
-                width={96}
-                height={96}
-                priority
-                style={{ width: 96, height: "auto" }}
-              />
-              <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
-                Traferr
-              </span>
+            <div className="relative inline-flex items-center justify-center">
+              <div className="inline-flex items-center rounded-full border border-white/80 bg-gradient-to-r from-white/95 via-white/90 to-sky-50/80 px-10 py-3 pl-16 text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-sky-600 shadow-lg shadow-sky-200/60 backdrop-blur">
+                <span className="sr-only">Traferr logo</span>
+                <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
+                  Traferr
+                </span>
+              </div>
+              <div className="pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 -translate-x-10 sm:-translate-x-12">
+                <div className="relative h-20 w-20 sm:h-24 sm:w-24">
+                  <div
+                    className="absolute inset-x-4 bottom-1 rounded-full bg-orange-400/50 blur-2xl"
+                    aria-hidden="true"
+                  />
+                  <Image
+                    src="/traferr-logo.svg"
+                    alt=""
+                    width={160}
+                    height={160}
+                    priority
+                    aria-hidden
+                    className="relative z-10 h-full w-full drop-shadow-[0_22px_40px_rgba(249,115,22,0.55)]"
+                  />
+                </div>
+              </div>
             </div>
             <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
               Have you talked to someone new today?

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,7 +31,8 @@ export default function Home() {
                 alt="Traferr logo"
                 width={96}
                 height={96}
-                className="h-12 w-auto"
+                priority
+                style={{ width: 96, height: "auto" }}
               />
               <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
                 Traferr

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import HowItWorks from "@/components/HowItWorks";
+import Image from "next/image";
 import Link from "next/link";
 import { SectionLink } from "@/components/SectionLink";
 
@@ -24,7 +25,14 @@ export default function Home() {
           style={{ paddingBottom: "var(--section-padding-block)" }}
         >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-            <span className="inline-flex items-center rounded-full border border-sky-200 bg-white/80 px-5 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-sky-600">
+            <span className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-white/80 px-5 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-sky-600">
+              <Image
+                src="/traferr-logo.svg"
+                alt="Traferr logo"
+                width={20}
+                height={20}
+                className="h-5 w-5 drop-shadow-sm"
+              />
               <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
                 Traferr
               </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,17 +81,39 @@ export default function Home() {
 
       <section id="why-i-need-this" className="px-4">
         <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-10 rounded-3xl border border-slate-200 bg-slate-50 px-6 py-16 shadow-xl shadow-sky-100/40">
-          <div className="max-w-2xl space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">
-              Why I need this
-            </p>
-            <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-              Social feeds broadcast. Traferr has a back-and-forth.
-            </h2>
-            <p className="text-base leading-relaxed text-slate-600">
-              Skip the endless scroll and tap into someone who actually lives there. It’s faster,
-              calmer, and finally personal.
-            </p>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-start">
+            <div className="max-w-2xl space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">
+                Why I need this
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+                Social feeds broadcast. Traferr has a back-and-forth.
+              </h2>
+              <p className="text-base leading-relaxed text-slate-600">
+                Skip the endless scroll and tap into someone who actually lives there. It’s faster,
+                calmer, and finally personal.
+              </p>
+            </div>
+            <div className="relative isolate overflow-hidden rounded-3xl border border-sky-100 bg-white p-3 shadow-[0_24px_80px_-40px_rgba(56,189,248,0.55)]">
+              <div className="aspect-video w-full overflow-hidden rounded-2xl bg-gradient-to-br from-sky-100 via-white to-sky-50">
+                {/* Replace this placeholder with your embedded video when it’s ready. */}
+                <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-slate-500">
+                  <div className="grid h-16 w-16 place-items-center rounded-full bg-white shadow-md shadow-sky-100">
+                    <svg
+                      aria-hidden="true"
+                      viewBox="0 0 24 24"
+                      className="h-7 w-7 fill-slate-400"
+                    >
+                      <path d="M8.25 6.75v10.5a.75.75 0 0 0 1.133.653l8.25-5.25a.75.75 0 0 0 0-1.306l-8.25-5.25a.75.75 0 0 0-1.133.653Z" />
+                    </svg>
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-slate-600">Video placeholder</p>
+                    <p className="text-xs text-slate-500">Drop your clip or embed code right here.</p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
           <div className="grid gap-6 md:grid-cols-2">
             <article className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,7 +126,7 @@ export default function Home() {
                 </article>
               </div>
             </div>
-            <div className="relative isolate overflow-hidden rounded-3xl border border-sky-100 bg-white p-3 shadow-[0_24px_80px_-40px_rgba(56,189,248,0.55)]">
+            <div className="relative isolate overflow-hidden rounded-3xl border border-sky-100 bg-white p-3 shadow-[0_24px_80px_-40px_rgba(56,189,248,0.55)] lg:self-center">
               <div className="aspect-video w-full overflow-hidden rounded-2xl bg-gradient-to-br from-sky-100 via-white to-sky-50">
                 {/* Replace this placeholder with your embedded video when it’s ready. */}
                 <div className="flex h-full flex-col items-center justify-center gap-3 text-center text-slate-500">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,13 +10,19 @@ const badges = [
 
 export default function Home() {
   return (
-    <div className="flex flex-col gap-24 pb-24">
+    <div
+      className="flex flex-col"
+      style={{ gap: "var(--section-gap)", paddingBottom: "var(--section-gap)" }}
+    >
       <section className="relative isolate overflow-hidden">
         <div
           className="pointer-events-none absolute inset-x-0 bottom-[-320px] h-[360px] rounded-full bg-sky-100 blur-3xl"
           aria-hidden
         />
-        <div className="mx-auto w-full max-w-screen-xl px-4 pb-24 pt-28 sm:pt-32">
+        <div
+          className="mx-auto w-full max-w-screen-xl px-4 pt-24 sm:pt-28 lg:pt-32"
+          style={{ paddingBottom: "var(--section-padding-block)" }}
+        >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
             <span className="inline-flex items-center rounded-full border border-sky-200 bg-white/80 px-5 py-1 text-xs font-semibold uppercase tracking-[0.32em] text-sky-600">
               <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
@@ -80,7 +86,13 @@ export default function Home() {
       <HowItWorks />
 
       <section id="why-i-need-this" className="px-4">
-        <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-10 rounded-3xl border border-slate-200 bg-slate-50 px-6 py-16 shadow-xl shadow-sky-100/40">
+        <div
+          className="mx-auto flex w-full max-w-screen-xl flex-col gap-10 rounded-3xl border border-slate-200 bg-slate-50 px-6 shadow-xl shadow-sky-100/40"
+          style={{
+            paddingTop: "var(--section-padding-block)",
+            paddingBottom: "var(--section-padding-block)",
+          }}
+        >
           <div className="grid gap-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start">
             <div className="flex flex-col gap-8">
               <div className="max-w-2xl space-y-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,17 +25,14 @@ export default function Home() {
           style={{ paddingBottom: "var(--section-padding-block)" }}
         >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-            <div className="relative inline-flex items-center gap-3 overflow-visible rounded-full border border-sky-200 bg-white/80 px-6 py-2 pl-16 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-sky-600 shadow-sm">
-              <span className="pointer-events-none absolute -left-11 top-1/2 flex h-20 w-20 -translate-y-1/2 items-center justify-center">
-                <span className="absolute inset-0 rounded-full bg-gradient-to-br from-sky-300 via-sky-400 to-indigo-400 opacity-60 blur-2xl" />
-                <Image
-                  src="/traferr-logo.svg"
-                  alt="Traferr logo"
-                  width={64}
-                  height={64}
-                  className="relative h-12 w-12 drop-shadow-[0_18px_36px_rgba(56,189,248,0.45)]"
-                />
-              </span>
+            <div className="inline-flex items-center gap-4 rounded-full border border-sky-200 bg-white/80 px-6 py-2 text-[0.7rem] font-semibold uppercase tracking-[0.32em] text-sky-600 shadow-sm">
+              <Image
+                src="/traferr-logo.svg"
+                alt="Traferr logo"
+                width={96}
+                height={96}
+                className="h-12 w-auto"
+              />
               <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
                 Traferr
               </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ const badges = [
 export default function Home() {
   return (
     <div className="flex flex-col gap-24 pb-24">
-      <section className="relative isolate overflow-hidden bg-gradient-to-b from-sky-50 via-white to-white">
+      <section className="relative isolate overflow-hidden">
         <div
           className="pointer-events-none absolute inset-x-0 bottom-[-320px] h-[360px] rounded-full bg-sky-100 blur-3xl"
           aria-hidden

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,30 +25,18 @@ export default function Home() {
           style={{ paddingBottom: "var(--section-padding-block)" }}
         >
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
-            <div className="relative inline-flex items-center justify-center">
-              <div className="inline-flex items-center rounded-full border border-white/80 bg-gradient-to-r from-white/95 via-white/90 to-sky-50/80 px-10 py-3 pl-16 text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-sky-600 shadow-lg shadow-sky-200/60 backdrop-blur">
-                <span className="sr-only">Traferr logo</span>
-                <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
-                  Traferr
-                </span>
-              </div>
-              <div className="pointer-events-none absolute left-0 top-1/2 -translate-y-1/2 -translate-x-10 sm:-translate-x-12">
-                <div className="relative h-20 w-20 sm:h-24 sm:w-24">
-                  <div
-                    className="absolute inset-x-4 bottom-1 rounded-full bg-orange-400/50 blur-2xl"
-                    aria-hidden="true"
-                  />
-                  <Image
-                    src="/traferr-logo.svg"
-                    alt=""
-                    width={160}
-                    height={160}
-                    priority
-                    aria-hidden
-                    className="relative z-10 h-full w-full drop-shadow-[0_22px_40px_rgba(249,115,22,0.55)]"
-                  />
-                </div>
-              </div>
+            <div className="inline-flex items-center gap-4 rounded-full border border-white/80 bg-white/90 px-8 py-3 text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-sky-600 shadow-lg shadow-sky-200/60 backdrop-blur">
+              <Image
+                src="/traferr-logo.svg"
+                alt="Traferr logo"
+                width={112}
+                height={136}
+                priority
+                className="h-12 w-auto sm:h-16"
+              />
+              <span className="bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text text-transparent">
+                Traferr
+              </span>
             </div>
             <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl lg:text-6xl">
               Have you talked to someone new today?

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -62,14 +62,14 @@ export function Header() {
       <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between px-4 py-4">
         <Link
           href="/"
-          className="inline-flex items-center gap-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          className="inline-flex items-center gap-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         >
           <Image
             src="/traferr-logo.svg"
             alt="Traferr logo"
-            width={32}
-            height={32}
-            className="h-8 w-8 drop-shadow"
+            width={44}
+            height={44}
+            className="h-11 w-11 drop-shadow-[0_12px_24px_rgba(56,189,248,0.35)]"
             priority
           />
           <span className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,9 +67,9 @@ export function Header() {
           <Image
             src="/traferr-logo.svg"
             alt="Traferr logo"
-            width={44}
-            height={44}
-            className="h-11 w-11 drop-shadow-[0_12px_24px_rgba(56,189,248,0.35)]"
+            width={64}
+            height={64}
+            className="h-11 w-auto"
             priority
           />
           <span className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -67,10 +67,10 @@ export function Header() {
           <Image
             src="/traferr-logo.svg"
             alt="Traferr logo"
-            width={64}
-            height={64}
+            width={96}
+            height={120}
             priority
-            style={{ width: 64, height: "auto" }}
+            className="h-12 w-auto sm:h-14"
           />
           <span className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl">
             Traferr

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { SectionLink } from "./SectionLink";
@@ -61,9 +62,19 @@ export function Header() {
       <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between px-4 py-4">
         <Link
           href="/"
-          className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl"
+          className="inline-flex items-center gap-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         >
-          Traferr
+          <Image
+            src="/traferr-logo.svg"
+            alt="Traferr logo"
+            width={32}
+            height={32}
+            className="h-8 w-8 drop-shadow"
+            priority
+          />
+          <span className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl">
+            Traferr
+          </span>
         </Link>
 
         <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 md:flex">

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -61,7 +61,7 @@ export function Header() {
       <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between px-4 py-4">
         <Link
           href="/"
-          className="text-lg font-semibold tracking-tight text-transparent bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 bg-clip-text"
+          className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl"
         >
           Traferr
         </Link>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -69,8 +69,8 @@ export function Header() {
             alt="Traferr logo"
             width={64}
             height={64}
-            className="h-11 w-auto"
             priority
+            style={{ width: 64, height: "auto" }}
           />
           <span className="text-xl font-black tracking-tight text-transparent bg-gradient-to-r from-sky-600 via-blue-500 to-indigo-500 bg-clip-text drop-shadow-sm sm:text-2xl md:text-3xl">
             Traferr

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -26,46 +26,43 @@ const steps = [
 export default function HowItWorks() {
   return (
     <section id="how-it-works" className="scroll-mt-24">
-      <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20">
-        {/* Heading */}
-        <p className="text-xs font-semibold tracking-widest text-sky-700 uppercase">
-          How it works
-        </p>
-        <h2 className="mt-2 text-3xl sm:text-4xl font-bold text-slate-900">
-          Three steps to a real conversation
-        </h2>
-        <p className="mt-3 text-slate-600 max-w-2xl">
-          Traferr removes the friction between your curiosity and the person who can answer it best.
-        </p>
-
-        {/* Layout */}
-        <div className="mt-10 grid grid-cols-1 md:grid-cols-12 gap-8 items-start">
-          {/* Mockup (sticky on desktop) */}
-          <div className="md:col-span-5">
-            <div className="md:sticky md:top-24">
-              <IPhoneFrame src="/app-screenshot.png" className="" />
-              <p className="mt-3 text-center text-xs text-slate-500">
-                (Drop your real screenshot at <code>/public/app-screenshot.png</code>; placeholder shown for now)
-              </p>
-            </div>
-          </div>
-
-          {/* Steps */}
-          <div className="md:col-span-7 space-y-6">
-            {steps.map((s) => (
-              <div
-                key={s.n}
-                className="relative overflow-hidden rounded-2xl border border-slate-200 bg-white/60 backdrop-blur shadow-sm p-6 sm:p-7"
-              >
-                <div className="absolute -left-3 -top-3 h-16 w-16 rounded-full bg-sky-50 ring-1 ring-sky-100 grid place-items-center text-sky-700 font-semibold">
-                  {s.n}
-                </div>
-                <h3 className="pl-12 text-lg font-semibold text-slate-900">{s.title}</h3>
-                <p className="pl-12 mt-2 text-slate-600">{s.body}</p>
-              </div>
-            ))}
-          </div>
+      <div className="mx-auto w-full max-w-screen-xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-sky-700">
+            How it works
+          </p>
+          <h2 className="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">
+            Three steps to a real conversation
+          </h2>
+          <p className="mt-4 text-base leading-relaxed text-slate-600 sm:text-lg">
+            Traferr removes the friction between your curiosity and the person who can answer it best.
+          </p>
         </div>
+
+        <div className="mt-16 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+          {steps.map((s) => (
+            <article
+              key={s.n}
+              className="relative flex h-full flex-col items-center rounded-3xl border border-slate-200 bg-white px-6 pb-10 pt-24 text-center shadow-sm shadow-slate-900/5 transition duration-200 hover:-translate-y-1 hover:shadow-xl hover:shadow-sky-100/60"
+            >
+              <div className="pointer-events-none absolute -top-16 left-1/2 flex -translate-x-1/2 justify-center">
+                <div className="rounded-[36px] bg-gradient-to-b from-slate-100 via-white to-slate-50 p-3 shadow-lg ring-1 ring-white/80">
+                  <IPhoneFrame src="/app-screenshot.png" size="sm" />
+                </div>
+              </div>
+
+              <span className="text-xs font-semibold uppercase tracking-[0.4em] text-sky-600">
+                Step {String(s.n).padStart(2, "0")}
+              </span>
+              <h3 className="mt-3 text-xl font-semibold text-slate-900">{s.title}</h3>
+              <p className="mt-4 text-base leading-relaxed text-slate-600">{s.body}</p>
+            </article>
+          ))}
+        </div>
+
+        <p className="mt-12 text-center text-xs text-slate-500">
+          Drop your real screenshot at <code>/public/app-screenshot.png</code>; a placeholder is shown for now.
+        </p>
       </div>
     </section>
   );

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -43,19 +43,23 @@ export default function HowItWorks() {
           {steps.map((s) => (
             <article
               key={s.n}
-              className="relative flex h-full flex-col items-center rounded-3xl border border-slate-200 bg-white px-6 pb-10 pt-24 text-center shadow-sm shadow-slate-900/5 transition duration-200 hover:-translate-y-1 hover:shadow-xl hover:shadow-sky-100/60"
+              className="relative flex h-full flex-col rounded-3xl border border-slate-200 bg-white p-8 text-left shadow-sm shadow-slate-900/5 transition duration-200 hover:-translate-y-1 hover:shadow-xl hover:shadow-sky-100/60"
             >
-              <div className="pointer-events-none absolute -top-16 left-1/2 flex -translate-x-1/2 justify-center">
-                <div className="rounded-[36px] bg-gradient-to-b from-slate-100 via-white to-slate-50 p-3 shadow-lg ring-1 ring-white/80">
-                  <IPhoneFrame src="/app-screenshot.png" size="sm" />
+              <div className="flex flex-col items-start gap-6 sm:flex-row">
+                <IPhoneFrame
+                  src="/app-screenshot.png"
+                  size="xs"
+                  className="mx-0 shrink-0 drop-shadow-[0_18px_40px_rgba(15,23,42,0.25)]"
+                />
+
+                <div className="text-left">
+                  <span className="block text-xs font-semibold uppercase tracking-[0.4em] text-sky-600">
+                    Step {String(s.n).padStart(2, "0")}
+                  </span>
+                  <h3 className="mt-3 text-xl font-semibold text-slate-900">{s.title}</h3>
+                  <p className="mt-4 text-base leading-relaxed text-slate-600">{s.body}</p>
                 </div>
               </div>
-
-              <span className="text-xs font-semibold uppercase tracking-[0.4em] text-sky-600">
-                Step {String(s.n).padStart(2, "0")}
-              </span>
-              <h3 className="mt-3 text-xl font-semibold text-slate-900">{s.title}</h3>
-              <p className="mt-4 text-base leading-relaxed text-slate-600">{s.body}</p>
             </article>
           ))}
         </div>

--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -26,7 +26,13 @@ const steps = [
 export default function HowItWorks() {
   return (
     <section id="how-it-works" className="scroll-mt-24">
-      <div className="mx-auto w-full max-w-screen-xl px-4 py-16 sm:px-6 sm:py-20 lg:px-8">
+      <div
+        className="mx-auto w-full max-w-screen-xl px-4 sm:px-6 lg:px-8"
+        style={{
+          paddingTop: "var(--section-padding-block)",
+          paddingBottom: "var(--section-padding-block)",
+        }}
+      >
         <div className="mx-auto max-w-3xl text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-sky-700">
             How it works

--- a/components/IPhoneFrame.tsx
+++ b/components/IPhoneFrame.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-type FrameSize = "sm" | "md" | "lg";
+type FrameSize = "xs" | "sm" | "md" | "lg";
 
 type Props = {
   /** Optional path to screenshot, e.g. "/app-screenshot.png". Falls back to placeholder SVG. */
@@ -11,30 +11,35 @@ type Props = {
 };
 
 const frameWidthClass: Record<FrameSize, string> = {
+  xs: "w-[140px]",
   sm: "w-[180px]",
   md: "w-[280px]",
   lg: "w-[320px] sm:w-[360px] md:w-[380px]",
 };
 
 const screenPaddingClass: Record<FrameSize, string> = {
+  xs: "m-[5px]",
   sm: "m-[6px]",
   md: "m-[8px]",
   lg: "m-[10px]",
 };
 
 const outerRadiusClass: Record<FrameSize, string> = {
+  xs: "rounded-[26px]",
   sm: "rounded-[32px]",
   md: "rounded-[38px]",
   lg: "rounded-[42px]",
 };
 
 const screenRadiusClass: Record<FrameSize, string> = {
+  xs: "rounded-[18px]",
   sm: "rounded-[22px]",
   md: "rounded-[26px]",
   lg: "rounded-[28px]",
 };
 
 const dynamicIslandClass: Record<FrameSize, string> = {
+  xs: "top-1.5 h-2.5 w-12",
   sm: "top-1.5 h-3 w-16",
   md: "top-2 h-3.5 w-20",
   lg: "top-2 h-4 sm:h-5 w-24 sm:w-28",
@@ -47,14 +52,15 @@ export default function IPhoneFrame({
   size = "lg",
 }: Props) {
   const imageSrc = src || "/placeholder-screenshot.svg";
+  const containerClassName = className || "mx-auto";
 
   return (
-    <div className={`mx-auto ${className}`}>
+    <div className={containerClassName}>
       {/* Phone shell */}
-      <div className={`relative mx-auto ${frameWidthClass[size]}`}>
+      <div className={`relative ${frameWidthClass[size]}`}>
         {/* Outer rounded bezel */}
         <div
-          className={`relative ${outerRadiusClass[size]} bg-neutral-900/95 shadow-2xl ring-1 ring-black/40`}
+          className={`relative ${outerRadiusClass[size]} bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 shadow-[0_18px_45px_rgba(15,23,42,0.35)]`}
         >
           {/* Screen area with padding to simulate bezel */}
           <div
@@ -67,7 +73,7 @@ export default function IPhoneFrame({
                 alt={alt}
                 fill
                 priority
-                className="object-cover rounded-[28px]"
+                className={`object-cover ${screenRadiusClass[size]}`}
                 sizes="(max-width: 768px) 320px, 380px"
               />
             </div>

--- a/components/IPhoneFrame.tsx
+++ b/components/IPhoneFrame.tsx
@@ -1,23 +1,65 @@
 import Image from "next/image";
 
+type FrameSize = "sm" | "md" | "lg";
+
 type Props = {
   /** Optional path to screenshot, e.g. "/app-screenshot.png". Falls back to placeholder SVG. */
   src?: string;
   alt?: string;
   className?: string;
+  size?: FrameSize;
 };
 
-export default function IPhoneFrame({ src, alt = "Traferr app", className = "" }: Props) {
+const frameWidthClass: Record<FrameSize, string> = {
+  sm: "w-[180px]",
+  md: "w-[280px]",
+  lg: "w-[320px] sm:w-[360px] md:w-[380px]",
+};
+
+const screenPaddingClass: Record<FrameSize, string> = {
+  sm: "m-[6px]",
+  md: "m-[8px]",
+  lg: "m-[10px]",
+};
+
+const outerRadiusClass: Record<FrameSize, string> = {
+  sm: "rounded-[32px]",
+  md: "rounded-[38px]",
+  lg: "rounded-[42px]",
+};
+
+const screenRadiusClass: Record<FrameSize, string> = {
+  sm: "rounded-[22px]",
+  md: "rounded-[26px]",
+  lg: "rounded-[28px]",
+};
+
+const dynamicIslandClass: Record<FrameSize, string> = {
+  sm: "top-1.5 h-3 w-16",
+  md: "top-2 h-3.5 w-20",
+  lg: "top-2 h-4 sm:h-5 w-24 sm:w-28",
+};
+
+export default function IPhoneFrame({
+  src,
+  alt = "Traferr app",
+  className = "",
+  size = "lg",
+}: Props) {
   const imageSrc = src || "/placeholder-screenshot.svg";
 
   return (
     <div className={`mx-auto ${className}`}>
       {/* Phone shell */}
-      <div className="relative mx-auto w-[320px] sm:w-[360px] md:w-[380px]">
+      <div className={`relative mx-auto ${frameWidthClass[size]}`}>
         {/* Outer rounded bezel */}
-        <div className="relative rounded-[42px] bg-neutral-900/95 shadow-2xl ring-1 ring-black/40">
+        <div
+          className={`relative ${outerRadiusClass[size]} bg-neutral-900/95 shadow-2xl ring-1 ring-black/40`}
+        >
           {/* Screen area with padding to simulate bezel */}
-          <div className="relative m-[10px] rounded-[28px] bg-black overflow-hidden">
+          <div
+            className={`relative ${screenPaddingClass[size]} ${screenRadiusClass[size]} bg-black overflow-hidden`}
+          >
             {/* Maintain iPhone-ish aspect ratio via padding trick */}
             <div className="relative w-full" style={{ paddingTop: "210%" }}>
               <Image
@@ -32,7 +74,9 @@ export default function IPhoneFrame({ src, alt = "Traferr app", className = "" }
           </div>
 
           {/* Dynamic island */}
-          <div className="absolute left-1/2 -translate-x-1/2 top-2 h-4 sm:h-5 w-24 sm:w-28 rounded-full bg-black/90 shadow-inner" />
+          <div
+            className={`absolute left-1/2 -translate-x-1/2 ${dynamicIslandClass[size]} rounded-full bg-black/90 shadow-inner`}
+          />
         </div>
       </div>
     </div>

--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -36,14 +36,14 @@ export function SiteShell({ children }: SiteShellProps) {
         <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+            className="inline-flex items-center gap-3 text-lg font-semibold tracking-tight text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
           >
             <Image
               src="/traferr-logo.svg"
               alt="Traferr logo"
-              width={28}
-              height={28}
-              className="h-7 w-7 drop-shadow-sm"
+              width={36}
+              height={36}
+              className="h-9 w-9 drop-shadow-[0_10px_22px_rgba(56,189,248,0.3)]"
             />
             <span>Traferr</span>
           </Link>

--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -41,9 +41,9 @@ export function SiteShell({ children }: SiteShellProps) {
             <Image
               src="/traferr-logo.svg"
               alt="Traferr logo"
-              width={36}
-              height={36}
-              className="h-9 w-9 drop-shadow-[0_10px_22px_rgba(56,189,248,0.3)]"
+              width={64}
+              height={64}
+              className="h-9 w-auto"
             />
             <span>Traferr</span>
           </Link>

--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { ContactModal } from "./ContactModal";
@@ -33,8 +34,18 @@ export function SiteShell({ children }: SiteShellProps) {
     <div className="flex min-h-screen flex-col bg-white text-slate-900">
       <header className="border-b border-slate-200 bg-white/80 backdrop-blur">
         <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
-          <Link href="/" className="text-lg font-semibold tracking-tight text-slate-900">
-            Traferr
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          >
+            <Image
+              src="/traferr-logo.svg"
+              alt="Traferr logo"
+              width={28}
+              height={28}
+              className="h-7 w-7 drop-shadow-sm"
+            />
+            <span>Traferr</span>
           </Link>
           <nav className="hidden items-center gap-6 text-sm font-medium text-slate-600 md:flex">
             {navigationLinks.map((link) => (

--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -43,7 +43,7 @@ export function SiteShell({ children }: SiteShellProps) {
               alt="Traferr logo"
               width={64}
               height={64}
-              className="h-9 w-auto"
+              style={{ width: 64, height: "auto" }}
             />
             <span>Traferr</span>
           </Link>

--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -41,9 +41,9 @@ export function SiteShell({ children }: SiteShellProps) {
             <Image
               src="/traferr-logo.svg"
               alt="Traferr logo"
-              width={64}
-              height={64}
-              style={{ width: 64, height: "auto" }}
+              width={96}
+              height={120}
+              className="h-12 w-auto sm:h-14"
             />
             <span>Traferr</span>
           </Link>

--- a/public/traferr-logo.svg
+++ b/public/traferr-logo.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img">
+  <defs>
+    <linearGradient id="traferrGradient" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffb347" />
+      <stop offset="100%" stop-color="#ff6b00" />
+    </linearGradient>
+    <linearGradient id="traferrHighlight" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffe7b3" stop-opacity="0.85" />
+      <stop offset="100%" stop-color="#ff8a3d" stop-opacity="0.35" />
+    </linearGradient>
+  </defs>
+  <path
+    d="M128 112a128 128 0 0 1 256 0v40c0 22.09-17.91 40-40 40h-32c-22.09 0-40-17.91-40-40v-16h-32v16c0 22.09-17.91 40-40 40h-32c-22.09 0-40-17.91-40-40v-40Z"
+    fill="url(#traferrGradient)"
+  />
+  <path
+    d="M256 160c-79.53 0-144 64.47-144 144 0 113.7 144 248 144 248s144-134.3 144-248c0-79.53-64.47-144-144-144Zm0 224a80 80 0 1 1 0-160 80 80 0 0 1 0 160Z"
+    fill="url(#traferrGradient)"
+  />
+  <circle cx="256" cy="304" r="72" fill="url(#traferrHighlight)" />
+</svg>


### PR DESCRIPTION
## Summary
- redesign the How It Works section into a three-card horizontal layout with centered copy
- add mini phone mockups above each step using the reusable iPhone frame component with a new small size option

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ceb7202b8c832ebb761b498c95994f