### PR TITLE
Fix favicon image path

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 64 64" role="img" aria-labelledby="title">
   <title id="title">Traferr favicon</title>
   <image
-    href="traferr-logo.png"
-    xlink:href="traferr-logo.png"
+    href="/traferr-logo.png"
+    xlink:href="/traferr-logo.png"
     width="64"
     height="64"
     preserveAspectRatio="xMidYMid meet"

--- a/public/traferr-logo.svg
+++ b/public/traferr-logo.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 512 512" role="img" aria-labelledby="title">
   <title id="title">Traferr logo</title>
   <image
-    href="traferr-logo.png"
-    xlink:href="traferr-logo.png"
+    href="/traferr-logo.png"
+    xlink:href="/traferr-logo.png"
     width="512"
     height="512"
     preserveAspectRatio="xMidYMid meet"


### PR DESCRIPTION
## Summary
- update the favicon SVG to reference the uploaded PNG with an absolute path so the icon resolves in deployments
- adjust the logo SVG wrapper to point at the same absolute PNG path

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf912643ec832e9726c1fab91b6bf7