### PR TITLE
Fix logo rendering by using PNG asset

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
           <div className="mx-auto flex max-w-3xl flex-col items-center gap-8 text-center">
             <div className="inline-flex items-center gap-4 rounded-full border border-white/80 bg-white/90 px-8 py-3 text-[0.7rem] font-semibold uppercase tracking-[0.38em] text-sky-600 shadow-lg shadow-sky-200/60 backdrop-blur">
               <Image
-                src="/traferr-logo.svg"
+                src="/traferr-logo.png"
                 alt="Traferr logo"
                 width={112}
                 height={136}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -65,7 +65,7 @@ export function Header() {
           className="inline-flex items-center gap-3 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
         >
           <Image
-            src="/traferr-logo.svg"
+            src="/traferr-logo.png"
             alt="Traferr logo"
             width={96}
             height={120}

--- a/components/SiteShell.tsx
+++ b/components/SiteShell.tsx
@@ -39,7 +39,7 @@ export function SiteShell({ children }: SiteShellProps) {
             className="inline-flex items-center gap-3 text-lg font-semibold tracking-tight text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
           >
             <Image
-              src="/traferr-logo.svg"
+              src="/traferr-logo.png"
               alt="Traferr logo"
               width={96}
               height={120}


### PR DESCRIPTION
## Summary
- replace the SVG logo reference with the PNG asset so the logo renders correctly when optimized
- update the header, hero, and shared shell components to use the PNG logo consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf93723028832e958bd65675a5ec4f