### PR TITLE
Adjust hero pin positioning

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -50,7 +50,7 @@ html {
   display: inline-flex;
   align-items: center;
   gap: clamp(1.2rem, 0.7vw + 1rem, 1.6rem);
-  padding: 0.65rem clamp(2rem, 3.4vw, 2.7rem) 0.65rem clamp(3.1rem, 4.8vw, 3.6rem);
+  padding: 0.65rem clamp(2rem, 3.4vw, 2.7rem) 0.65rem clamp(2.6rem, 4vw, 3.1rem);
   border-radius: 999px;
   border: 1px solid rgba(255, 255, 255, 0.6);
   background: rgba(255, 255, 255, 0.82);
@@ -64,10 +64,10 @@ html {
 .hero-pin {
   position: absolute;
   top: 50%;
-  left: clamp(-2.85rem, -3.9vw, -2.35rem);
+  left: clamp(-1.85rem, -2.9vw, -1.45rem);
   width: clamp(4.1rem, 7vw, 4.9rem);
   height: clamp(4.1rem, 7vw, 4.9rem);
-  transform: translate(-6%, -52%);
+  transform: translate(-2%, -52%);
   pointer-events: none;
   filter: drop-shadow(0 20px 40px rgba(14, 116, 144, 0.38));
 }


### PR DESCRIPTION
## Summary
- shift the hero pin positioning so the logo sits closer to the badge text
- rebalance the badge padding to keep the wordmark centered after the pin adjustment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d01840c110832eba8041e6d5400286