### PR TITLE
Add DownloadPopup modal for hero CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import HowItWorks from "@/components/HowItWorks";
 import Image from "next/image";
-import Link from "next/link";
 import { SectionLink } from "@/components/SectionLink";
+import DownloadPopup from "@/components/DownloadPopup";
 
 const badges = [
   "Connect to Locals",
@@ -67,12 +67,7 @@ export default function Home() {
               </span>
             </p>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-              <Link
-                href="/contact"
-                className="inline-flex items-center justify-center rounded-full bg-sky-500 px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200/60 transition hover:bg-sky-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
-              >
-                Start a conversation
-              </Link>
+              <DownloadPopup />
               <SectionLink
                 targetId="how-it-works"
                 className="inline-flex items-center justify-center gap-2 rounded-full border border-slate-200 bg-white/80 px-8 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"

--- a/components/DownloadPopup.tsx
+++ b/components/DownloadPopup.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type DownloadPopupProps = {
+  className?: string;
+};
+
+export default function DownloadPopup({ className = "" }: DownloadPopupProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeModal();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, closeModal]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className={`inline-flex items-center justify-center rounded-full bg-sky-500 px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200/60 transition hover:bg-sky-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${className}`.trim()}
+      >
+        Start a conversation
+      </button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-8 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="download-popup-title"
+          onClick={closeModal}
+        >
+          <div
+            className="relative w-full max-w-md space-y-6 rounded-3xl bg-white p-8 text-center shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={closeModal}
+              className="absolute right-5 top-5 rounded-full bg-slate-100 px-2.5 py-1 text-sm font-semibold text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400"
+              aria-label="Close download popup"
+            >
+              ×
+            </button>
+            <div className="space-y-3">
+              <h2 id="download-popup-title" className="text-2xl font-semibold text-slate-900">
+                Get the Traferr app
+              </h2>
+              <p className="text-sm text-slate-600">
+                Pick your platform to download Traferr and start connecting with locals.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:border-slate-300 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"
+              >
+                Download Android
+              </button>
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+              >
+                Download Apple
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/components/DownloadPopup.tsx
+++ b/components/DownloadPopup.tsx
@@ -38,7 +38,12 @@ export default function DownloadPopup({ className = "" }: DownloadPopupProps) {
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className={`inline-flex items-center justify-center rounded-full bg-sky-500 px-8 py-3 text-sm font-semibold text-white shadow-lg shadow-sky-200/60 transition hover:bg-sky-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 ${className}`.trim()}
+        aria-expanded={isOpen}
+        className={`inline-flex items-center justify-center rounded-full px-8 py-3 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+          isOpen
+            ? "bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 shadow-[0_14px_30px_-16px_rgba(249,115,22,0.75)] hover:shadow-[0_18px_36px_-18px_rgba(249,115,22,0.85)] focus-visible:outline-orange-400"
+            : "bg-sky-500 shadow-lg shadow-sky-200/60 hover:bg-sky-600 focus-visible:outline-sky-500"
+        } ${className}`.trim()}
       >
         Start a conversation
       </button>

--- a/components/DownloadPopup.tsx
+++ b/components/DownloadPopup.tsx
@@ -74,7 +74,7 @@ export default function DownloadPopup({ className = "" }: DownloadPopupProps) {
             <div className="grid gap-3 sm:grid-cols-2">
               <button
                 type="button"
-                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:border-slate-300 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-500"
+                className="inline-flex items-center justify-center rounded-full border-0 bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 px-6 py-3 text-sm font-semibold text-white shadow-[0_14px_30px_-16px_rgba(249,115,22,0.75)] transition hover:shadow-[0_18px_36px_-18px_rgba(249,115,22,0.85)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400"
               >
                 Download Android
               </button>


### PR DESCRIPTION
## Summary
- add a DownloadPopup component that renders a modal with Android and Apple download buttons
- open the modal from the hero “Start a conversation” button with a blurred overlay and dismiss controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9141cd0b8832e8ac7c21e16ca4b29