### PR TITLE
Update download popup hover styles and link destinations

### DIFF
--- a/components/DownloadPopup.tsx
+++ b/components/DownloadPopup.tsx
@@ -77,18 +77,22 @@ export default function DownloadPopup({ className = "" }: DownloadPopupProps) {
               </p>
             </div>
             <div className="grid gap-3 sm:grid-cols-2">
-              <button
-                type="button"
-                className="inline-flex items-center justify-center rounded-full border-0 bg-gradient-to-r from-orange-500 via-amber-400 to-pink-500 px-6 py-3 text-sm font-semibold text-white shadow-none transition hover:shadow-[0_18px_36px_-18px_rgba(249,115,22,0.85)] focus-visible:shadow-[0_18px_36px_-18px_rgba(249,115,22,0.85)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400"
+              <a
+                href="https://play.google.com/store/apps/details?id=com.traferr"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:border-orange-200 hover:bg-orange-50 hover:text-orange-600 hover:shadow-[0_16px_40px_-18px_rgba(249,115,22,0.55)] focus-visible:text-orange-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-400"
               >
                 Download Android
-              </button>
-              <button
-                type="button"
-                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-none transition hover:border-slate-300 hover:bg-slate-50 hover:shadow-[0_14px_30px_-18px_rgba(14,165,233,0.35)] focus-visible:shadow-[0_14px_30px_-18px_rgba(14,165,233,0.35)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+              </a>
+              <a
+                href="https://apps.apple.com/us/app/traferr-the-world-is-yours/id6744027186"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold text-slate-900 shadow-sm transition hover:border-sky-200 hover:bg-sky-50 hover:text-sky-600 hover:shadow-[0_16px_40px_-18px_rgba(14,165,233,0.45)] focus-visible:text-sky-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
               >
                 Download Apple
-              </button>
+              </a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace the static gradient download buttons with neutral styles that gain a glow on hover
- convert the buttons into external links to the Android and Apple Traferr app store pages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dfbe7ea660832e9296135bd60588bb